### PR TITLE
add push notification boilerplate

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -31,9 +31,10 @@ schemars = { version = "0.8.11" }
 serde = { version = "1.0" }
 thiserror = { version = "1.0" }
 cosmwasm-schema = "1.0.0"
+minicbor-ser = "0.2.0"
 
 # Uncomment these for some common extra tools
-secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit", tag = "v0.10.0" }
+secret-toolkit = { git = "https://github.com/SolarRepublic/secret-toolkit", features = ["permit", "notification"], rev = "8aed92d589dc119f69d20f8538d5a6eea8003d95" }
 # cw-storage-plus = { version = "1.0.1", default-features = false }
 
 # [patch.crates-io]

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -1,12 +1,18 @@
 
-use cosmwasm_std::{from_binary, Addr, Uint128};
+use cosmwasm_std::{from_binary, Addr, CanonicalAddr, Uint128, Uint64};
 use cosmwasm_std::{
     entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
 };
+use secret_toolkit::crypto::{hkdf_sha_256, sha_256, ContractPrng};
+use secret_toolkit::notification::{get_seed, notification_id, ChannelInfoData, Notification, NotificationData};
+use secret_toolkit::permit::Permit;
 
-use crate::msg::{ContractsResponse, ExecuteMsg, ExecuteReceiveMsg, InstantiateMsg, QueryMsg};
-use crate::state::{config, config_read, ClientContract, Contract, State};
+use crate::msg::{ContractsResponse, ExecuteMsg, ExecuteReceiveMsg, InstantiateMsg, QueryAnswer, QueryMsg, QueryWithPermit};
+use crate::notify::AcceptedNotificationData;
+use crate::state::{config, config_read, ClientContract, Contract, State, SNIP52_INTERNAL_SECRET};
 use secret_toolkit::snip20::{register_receive_msg, transfer_msg};
+
+pub const SEED_LEN: usize = 32;
 
 #[entry_point]
 pub fn instantiate(
@@ -31,6 +37,19 @@ pub fn instantiate(
         "secret1kw9ajrrhxxx6tdms543r92rs2ml8uqt5vsek8v".to_string(),
     )?;
 
+    // SNIP-52 init
+    // create an internal secret
+    let rng_seed = env.block.random.as_ref().unwrap();
+    let mut prng = ContractPrng::from_env(&env);
+    let salt = Some(sha_256(&prng.rand_bytes()).to_vec());
+    let internal_secret = hkdf_sha_256(
+        &salt,
+        rng_seed.0.as_slice(),
+        "contract_internal_secret".as_bytes(),
+        SEED_LEN,
+    )?;
+    SNIP52_INTERNAL_SECRET.save(deps.storage, &internal_secret)?;
+
     Ok(Response::new()
         .add_message(register_msg)
     )
@@ -39,15 +58,17 @@ pub fn instantiate(
 #[entry_point]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     match msg {
-        ExecuteMsg::Receive { sender, from, amount, msg } => try_receive(deps, info, sender, from, amount, msg),
+        ExecuteMsg::Receive { sender, from, amount, msg } => try_receive(deps, env, info, sender, from, amount, msg),
     }
 }
 
-pub fn try_receive(deps: DepsMut, info: MessageInfo, sender: Addr, from: Addr, amount: Uint128, msg: Option<Binary>) -> StdResult<Response> {
+pub fn try_receive(deps: DepsMut, env: Env, info: MessageInfo, sender: Addr, from: Addr, amount: Uint128, msg: Option<Binary>) -> StdResult<Response> {
     
     deps.api.debug("callback called");
 
     let mut res = Response::default();
+    let secret = SNIP52_INTERNAL_SECRET.load(deps.storage)?;
+    let secret = secret.as_slice();
 
     if let Some(msg) = msg {
         match from_binary(&msg)? {
@@ -103,7 +124,22 @@ pub fn try_receive(deps: DepsMut, info: MessageInfo, sender: Addr, from: Addr, a
                         )?;
                         deps.api.debug(&format!("Acceptance Transfer Message {:?}", acceptance_transfer_message));
 
-                        res = Response::default().add_message(intial_transfer_message).add_message(acceptance_transfer_message);
+                        // SNIP-52 add `accepted` push notification
+                        let notification = Notification::new(
+                            Addr::unchecked(contract.user_wallet_address.clone()),
+                            AcceptedNotificationData {
+                                id: id.clone(),
+                            }
+                        )
+                        .to_txhash_notification(deps.api, &env, secret, None)?;
+
+                        res = Response::default()
+                            .add_message(intial_transfer_message)
+                            .add_message(acceptance_transfer_message)
+                            .add_attribute_plaintext(
+                                notification.id_plaintext(),
+                                notification.data_plaintext(),
+                            );
                         
                         state.contracts.retain(|contract| contract.id != id);
 
@@ -121,9 +157,38 @@ pub fn try_receive(deps: DepsMut, info: MessageInfo, sender: Addr, from: Addr, a
 
 
 #[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::GetContracts {} => to_binary(&query_contracts(deps)?),
+        QueryMsg::WithPermit { permit, query } => permit_queries(deps, env, permit, query),
+    }
+}
+
+fn permit_queries(
+    deps: Deps,
+    env: Env,
+    permit: Permit,
+    query: QueryWithPermit,
+) -> Result<Binary, StdError> {
+    // Validate permit content
+    let token_address = env.contract.address.clone();
+
+    let account = secret_toolkit::permit::validate(
+        deps,
+        "revoked_permits",
+        &permit,
+        token_address.into_string(),
+        None,
+    )?;
+
+    match query {
+        QueryWithPermit::ChannelInfo { channels, txhash } => query_channel_info(
+            deps,
+            env,
+            channels,
+            txhash,
+            deps.api.addr_canonicalize(account.as_str())?,
+        ),
     }
 }
 
@@ -131,4 +196,58 @@ fn query_contracts(deps: Deps) -> StdResult<ContractsResponse> {
     let state = config_read(deps.storage).load()?;
     let client_contracts: Vec<ClientContract> = state.contracts.into_iter().map(ClientContract::from).collect();
     Ok(ContractsResponse { contracts: client_contracts })
+}
+
+///
+/// ChannelInfo query
+///
+///   Authenticated query allows clients to obtain the seed,
+///   and Notification ID of an event for a specific tx_hash, for a specific channel.
+///
+fn query_channel_info(
+    deps: Deps,
+    env: Env,
+    channels: Vec<String>,
+    txhash: Option<String>,
+    sender_raw: CanonicalAddr,
+) -> StdResult<Binary> {
+    let secret = SNIP52_INTERNAL_SECRET.load(deps.storage)?;
+    let secret = secret.as_slice();
+    let seed = get_seed(&sender_raw, secret)?;
+    let mut channels_data = vec![];
+    for channel in channels {
+        let answer_id;
+        if let Some(tx_hash) = &txhash {
+            answer_id = Some(notification_id(&seed, &channel, tx_hash)?);
+        } else {
+            answer_id = None;
+        }
+        match channel.as_str() {
+            AcceptedNotificationData::CHANNEL_ID => {
+                let channel_info_data = ChannelInfoData {
+                    mode: "txhash".to_string(),
+                    channel,
+                    answer_id,
+                    parameters: None,
+                    data: None,
+                    next_id: None,
+                    counter: None,
+                    cddl: Some(AcceptedNotificationData::CDDL_SCHEMA.to_string()),
+                };
+                channels_data.push(channel_info_data);
+            }
+            _ => {
+                return Err(StdError::generic_err(format!(
+                    "`{}` channel is undefined",
+                    channel
+                )));
+            }
+        }
+    }
+
+    to_binary(&QueryAnswer::ChannelInfo {
+        as_of_block: Uint64::from(env.block.height),
+        channels: channels_data,
+        seed,
+    })
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod contract;
 pub mod msg;
 pub mod state;
+pub mod notify;

--- a/contract/src/msg.rs
+++ b/contract/src/msg.rs
@@ -1,5 +1,6 @@
-use cosmwasm_std::{Addr, Binary, Uint128};
+use cosmwasm_std::{Addr, Binary, Uint128, Uint64};
 use schemars::JsonSchema;
+use secret_toolkit::{notification::ChannelInfoData, permit::Permit};
 use serde::{Deserialize, Serialize};
 use crate::state::ClientContract;
 
@@ -29,10 +30,38 @@ pub enum ExecuteReceiveMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     GetContracts {},
+    WithPermit {
+        permit: Permit,
+        query: QueryWithPermit,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+#[serde(rename_all = "snake_case")]
+pub enum QueryWithPermit {
+    // SNIP-52 Private Push Notifications
+    ChannelInfo {
+        channels: Vec<String>,
+        txhash: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryAnswer {
+    ChannelInfo {
+        /// scopes validity of this response
+        as_of_block: Uint64,
+        /// shared secret in base64
+        seed: Binary,
+        channels: Vec<ChannelInfoData>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]

--- a/contract/src/notify.rs
+++ b/contract/src/notify.rs
@@ -1,0 +1,22 @@
+use cosmwasm_std::StdError;
+use secret_toolkit::notification::NotificationData;
+use minicbor_ser as cbor;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Debug, Deserialize, Clone)]
+pub struct AcceptedNotificationData {
+    pub id: String,
+    // maybe add other fields?
+}
+
+impl NotificationData for AcceptedNotificationData {
+    const CHANNEL_ID: &'static str = "accepted";
+    const CDDL_SCHEMA: &'static str = "accepted=[id:tstr]";
+    fn to_cbor(&self, _api: &dyn cosmwasm_std::Api) -> cosmwasm_std::StdResult<Vec<u8>> {
+        let my_data = cbor::to_vec(&(
+            self.id.as_bytes(),
+        ))
+        .map_err(|e| StdError::generic_err(format!("{:?}", e)))?;
+        Ok(my_data)
+    }
+}

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -1,4 +1,5 @@
 use schemars::JsonSchema;
+use secret_toolkit::storage::Item;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Storage, Uint128};
@@ -57,3 +58,6 @@ pub fn config(storage: &mut dyn Storage) -> Singleton<State> {
 pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<State> {
     singleton_read(storage, CONFIG_KEY)
 }
+
+// SNIP-52 Private Push Notifications
+pub static SNIP52_INTERNAL_SECRET: Item<Vec<u8>> = Item::new(b"snip52-secret");

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slider": "^1.2.0",
         "@radix-ui/themes": "^3.1.3",
+        "@solar-republic/neutrino": "^1.5.5",
         "@tailwindcss/forms": "^0.5.9",
         "autoprefixer": "^10.4.20",
         "bootstrap-icons": "^1.11.3",
@@ -376,6 +377,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blake.regalia/belt": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@blake.regalia/belt/-/belt-0.37.0.tgz",
+      "integrity": "sha512-kpAXIn9ioUBVRjwvtyyjZRzwQ2MRJbI/AKY+4maQZD+daG/9tbCN0ET8BP9WzfqD0jZ8i5TIjEByjUdWpzn1MQ=="
     },
     "node_modules/@cosmjs/encoding": {
       "version": "0.27.1",
@@ -3054,6 +3060,70 @@
         "win32"
       ]
     },
+    "node_modules/@solar-republic/cosmos-grpc": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@solar-republic/cosmos-grpc/-/cosmos-grpc-0.17.1.tgz",
+      "integrity": "sha512-5w49cExdiL+/EczMuUG/yj/lLciQwheKWfhA7jshyKDKKEovcdpVjloH6VIWuSUv3lLBxGt7F20UbT4DcAzeqQ==",
+      "dependencies": {
+        "@solar-republic/crypto": "^0.2.14",
+        "google-protobuf": "^3.21.2",
+        "protobufjs": "7.2.6"
+      },
+      "bin": {
+        "protoc-gen-secret": "build/protoc/run.js"
+      }
+    },
+    "node_modules/@solar-republic/cosmos-grpc/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@solar-republic/crypto": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@solar-republic/crypto/-/crypto-0.2.14.tgz",
+      "integrity": "sha512-lm9U5QuBamqYAsdrJsnVfE7Uef4TyCvgLsgypPI1/RNjFdRCeKpMXoCRmJxeu3m/FzOhmPvX3WDd+ePCGw149w==",
+      "dependencies": {
+        "@blake.regalia/belt": "^0.37.0",
+        "@solar-republic/wasm-secp256k1": "^0.2.8",
+        "hash-wasm": "^4.11.0"
+      }
+    },
+    "node_modules/@solar-republic/neutrino": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@solar-republic/neutrino/-/neutrino-1.5.5.tgz",
+      "integrity": "sha512-3MQa7nEmfHh52nA2eOImU5ACoXZ+0YzUr+8tJReIwY+LJwtsH/EGGFh6/p68kOp9Y4Bu5ssihlIfta6ikaa4Vw==",
+      "dependencies": {
+        "@blake.regalia/belt": "^0.37.0",
+        "@solar-republic/cosmos-grpc": "^0.17.1",
+        "@solar-republic/crypto": "^0.2.14"
+      }
+    },
+    "node_modules/@solar-republic/wasm-secp256k1": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@solar-republic/wasm-secp256k1/-/wasm-secp256k1-0.2.8.tgz",
+      "integrity": "sha512-tFSO+YOqZt/E6EvrjxhxcrPAn8hs5cPx2Op/+rzznrQuMHEONxvb3MFiw9V8JbcMvrMiCypLvFR7nkrI8+h3sg==",
+      "dependencies": {
+        "@blake.regalia/belt": "^0.37.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -4822,6 +4892,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.11.0.tgz",
+      "integrity": "sha512-HVusNXlVqHe0fzIzdQOGolnFN6mX/fqcrSAOcTBXdvzrXVHwTz11vXeKRmkR5gTuwVpvHZEIyKoePDvuAR+XwQ=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",

--- a/www/package.json
+++ b/www/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slider": "^1.2.0",
     "@radix-ui/themes": "^3.1.3",
+    "@solar-republic/neutrino": "^1.5.5",
     "@tailwindcss/forms": "^0.5.9",
     "autoprefixer": "^10.4.20",
     "bootstrap-icons": "^1.11.3",

--- a/www/src/pages/Trade.tsx
+++ b/www/src/pages/Trade.tsx
@@ -7,6 +7,7 @@ import NoResults from "../components/common/NoResults";
 import { try_query_contracts } from "../util/secretClient";
 import TradeItem from "../components/TradeItem";
 import AcceptTradeModel from "../components/AcceptTradeModel";
+import { notifyExample } from '../util/notify'
 
 const Trade = () => {
 
@@ -101,7 +102,6 @@ const Trade = () => {
     });
   }, []);
 
-
   return (
     <div className="flex flex-col min-h-screen w-screen items-center">
       <Title title="Trade" description="Browse Global Contracts" />
@@ -169,6 +169,8 @@ const Trade = () => {
               )}
 
             </div>
+
+            <button className="p-3 bg-white rounded-xl" onClick={() => notifyExample()}>Notifications</button>
 
             {/* Pagination */}
             <div className="w-full flex justify-center items-center mt-5 mb-20 gap-4 rounded-xl">

--- a/www/src/util/notify.ts
+++ b/www/src/util/notify.ts
@@ -1,0 +1,63 @@
+import {subscribe_snip52_channels} from '@solar-republic/neutrino';
+import { SecretNetworkClient } from 'secretjs';
+
+const contractAddress = import.meta.env.VITE_contractAddress;
+
+async function getPermit(address: string) {
+    const permitName = "channel-info";
+    const allowedTokens = [import.meta.env.VITE_contractAddress];
+    const permissions = ["owner"];
+    const chainId = "secretdev-1";
+
+    const { signature } = await window.keplr.signAmino(
+        chainId,
+        address,
+        {
+            chain_id: chainId,
+            account_number: "0", // Must be 0
+            sequence: "0", // Must be 0
+            fee: {
+                amount: [{ denom: "uscrt", amount: "0" }], // Must be 0 uscrt
+                gas: "1", // Must be 1
+            },
+            msgs: [
+                {
+                    type: "query_permit", // Must be "query_permit"
+                    value: {
+                        permit_name: permitName,
+                        allowed_tokens: allowedTokens,
+                        permissions: permissions,
+                    },
+                },
+            ],
+            memo: "", // Must be empty
+        },
+        {
+            preferNoSetFee: true, // Fee must be 0, so hide it from the user
+            preferNoSetMemo: true, // Memo must be empty, so hide it from the user
+        }
+    );
+    let permit = {
+        params: {
+          permit_name: permitName,
+          allowed_tokens: allowedTokens,
+          chain_id: chainId,
+          permissions,
+        },
+        signature: signature,
+    };
+    return permit;
+}
+
+async function notifyExample(secretjs: SecretNetworkClient) {
+    const permit = getPermit(secretjs.address);
+    await subscribe_snip52_channels("http://localhost:26657", contractAddress, permit, {
+        accepted(data: [string]) {
+            const [accepted_id] = data;
+
+            // you got a notification for accepted id, do something with it here.
+            console.log(accepted_id);
+        }
+    })
+}
+

--- a/www/src/util/notify.ts
+++ b/www/src/util/notify.ts
@@ -1,5 +1,6 @@
-import {subscribe_snip52_channels} from '@solar-republic/neutrino';
+import {SecretContract, subscribe_snip52_channels} from '@solar-republic/neutrino';
 import { SecretNetworkClient } from 'secretjs';
+import { createExecuteClient } from './secretClient';
 
 const contractAddress = import.meta.env.VITE_contractAddress;
 
@@ -49,9 +50,14 @@ async function getPermit(address: string) {
     return permit;
 }
 
-async function notifyExample(secretjs: SecretNetworkClient) {
-    const permit = getPermit(secretjs.address);
-    await subscribe_snip52_channels("http://localhost:26657", contractAddress, permit, {
+export async function notifyExample() {
+    const client: SecretNetworkClient = await createExecuteClient();
+
+    const permit = await getPermit(client.address);
+
+    const contract = await SecretContract("http://localhost:1317", contractAddress);
+
+    await subscribe_snip52_channels("http://localhost:26657", contract, permit, {
         accepted(data: [string]) {
             const [accepted_id] = data;
 

--- a/www/src/util/secretClient.ts
+++ b/www/src/util/secretClient.ts
@@ -14,7 +14,7 @@ const createQueryClient = async () => {
 }
 
 // SecretJS Client to perform execute messages. Requires a connected wallet.
-const createExecuteClient = async () => {
+export const createExecuteClient = async () => {
 
   let client: any = new SecretNetworkClient({
     chainId: "secretdev-1",


### PR DESCRIPTION
I added code for the push notifications in this branch. 

You can define as many channels as you want-- I just created one for a notification once the trade is accepted. It only sends the id as a text string. If you want to add more fields add them to the struct and update the `to_cbor` function. https://github.com/geordiegibson/saffron/blob/snip52/contract/src/notify.rs#L7-L22

The data itself for the notification is set here and then it is added as a plaintext attribute to the logs: https://github.com/geordiegibson/saffron/blob/snip52/contract/src/contract.rs#L127-L142

If you add more channels then you also need to update the `query_channel_info` function here: https://github.com/geordiegibson/saffron/blob/snip52/contract/src/contract.rs#L225

For the front end, I added the neutrino lib which has a built-in function called `subscribe_snip52_channels`. It requires that you make a query permit, which you can do with Keplr. That could be done once (since it requires a user interaction with the wallet) and then just stored in local storage. Here's some basic code--- https://github.com/geordiegibson/saffron/blob/snip52/www/src/util/notify.ts#L54

haven't fully tested this, so let me know if you have any issues!